### PR TITLE
Fix timeout optional param

### DIFF
--- a/android/src/main/java/com/recaptchaenterprisereactnative/RecaptchaEnterpriseReactNativeModule.kt
+++ b/android/src/main/java/com/recaptchaenterprisereactnative/RecaptchaEnterpriseReactNativeModule.kt
@@ -89,13 +89,17 @@ class RecaptchaEnterpriseReactNativeModule(reactContext: ReactApplicationContext
       return
     }
 
-    // JS+ReadableMap have no support for long
-    val timeout = arguments.getDouble("timeout").toLong()
     val action = mapAction(actionStr)
 
     GlobalScope.launch {
       recaptchaClient
-        .let { if (arguments.hasKey("timeout")) it.execute(action, timeout) else it.execute(action) }
+        .let { if (arguments.hasKey("timeout")) {
+          // JS+ReadableMap have no support for long
+          val timeout = arguments.getDouble("timeout").toLong()
+          it.execute(action, timeout)
+        } else {
+          it.execute(action)
+        } }
         .onSuccess { token -> promise.resolve(token) }
         .onFailure { exception -> promise.reject(exception) }
     }


### PR DESCRIPTION
Currently the app crashes with NoSuchKeyException from react bridge since the code is trying to get "timeout" when it doesn't exist, this param should be optional, so you shouldn't try to fetch it unless it exist.