### PR TITLE
Fix circular dependency

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,25 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { NativeModules, Platform } from 'react-native';
 export { execute, initClient, Recaptcha } from './recaptcha';
 export { RecaptchaAction } from './recaptcha_action';
 export type { RecaptchaClient } from './recaptcha_client';
-
-const LINKING_ERROR =
-  `The package '@google-cloud/recaptcha-enterprise-react-native' doesn't seem to be linked. Make sure: \n\n` +
-  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
-  '- You rebuilt the app after installing the package\n' +
-  '- You are not using Expo Go\n';
-
-export const RecaptchaEnterpriseReactNative =
-  NativeModules.RecaptchaEnterpriseReactNative
-    ? NativeModules.RecaptchaEnterpriseReactNative
-    : new Proxy(
-        {},
-        {
-          get() {
-            throw new Error(LINKING_ERROR);
-          },
-        }
-      );

--- a/src/recaptcha.tsx
+++ b/src/recaptcha.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { RecaptchaEnterpriseReactNative } from './index';
+import { RecaptchaEnterpriseReactNative } from './recaptcha_native';
 import type { RecaptchaAction } from './recaptcha_action';
 import { type RecaptchaClient, RecaptchaClientImpl } from './recaptcha_client';
 

--- a/src/recaptcha_client.tsx
+++ b/src/recaptcha_client.tsx
@@ -1,4 +1,4 @@
-import { RecaptchaEnterpriseReactNative } from './index';
+import { RecaptchaEnterpriseReactNative } from './recaptcha_native';
 import type { RecaptchaAction } from './recaptcha_action';
 
 interface Args {

--- a/src/recaptcha_native.ts
+++ b/src/recaptcha_native.ts
@@ -1,0 +1,19 @@
+import { NativeModules, Platform } from 'react-native';
+
+const LINKING_ERROR =
+  `The package '@google-cloud/recaptcha-enterprise-react-native' doesn't seem to be linked. Make sure: \n\n` +
+  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
+  '- You rebuilt the app after installing the package\n' +
+  '- You are not using Expo Go\n';
+
+export const RecaptchaEnterpriseReactNative =
+  NativeModules.RecaptchaEnterpriseReactNative
+    ? NativeModules.RecaptchaEnterpriseReactNative
+    : new Proxy(
+        {},
+        {
+          get() {
+            throw new Error(LINKING_ERROR);
+          },
+        }
+      );

--- a/src/recaptcha_native.ts
+++ b/src/recaptcha_native.ts
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { NativeModules, Platform } from 'react-native';
 
 const LINKING_ERROR =

--- a/src/recaptcha_native.ts
+++ b/src/recaptcha_native.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix circular dependency by factoring out `RecaptchaEnterpriseReactNative` into a separate module.

Fixes #52